### PR TITLE
 [ServiceWorkers] Create a better algoritm to match urls (#1165858)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,38 @@ worker.post('/event/*', analyticsMiddleware);
 More than one middleware can be registered with one worker. You just need to keep in mind that the `request` and `response` objects will be passed to each middleware in the same order that they were registered.
 
 
+## Specifying routes
+
+While registering your middlewares, you are not limited just to predefined paths, you have the choice to specify your routes by using *placeholders*. You could use placeholders as wildcards that match several different routes and handle them in your middleware registration. These placeholders are loosely based on [Express' path strings](http://expressjs.com/guide/routing.html#route-paths).
+
+Currently supported placeholders include:
+
+* Anonymous placeholder: `*`  
+Can accomodate any number of characters (including the empty string):
+  * `"*"` is the universal route -- it will match any path  
+  ```javascript
+worker.get('*'); // matches any path
+```
+  * `"/foo*"` will match `/foo` and any path downstream (like `/foo/bar/baz`)  
+  ```javascript
+worker.get('/foo*'); // will match /foo and any subpaths
+```
+
+* Named placeholder: `:<placeholder-name>`  
+Can accomodate any substring, but doesn't allow the empty string (matches minimum 1 character).  
+The placeholder name could be any number of alphanumeric characters:  
+  * `"/:path"' will match `/foo` and `/foo/bar/baz`, but won't match `/`  
+  ```javascript
+worker.get('/:path'); // won't match / as :path must not be empty
+```
+
+You could use the backslash character to escape special placeholders (and specify literal asterisks and/or colon characters in your code). *Note: in JavaScript string literals you must double the backslash to achieve the intended effect.*
+
+```javascript
+worker.get('/:param\\:42'); // will match /x:42 and /answer/is:42
+```
+
+
 ## Writing a middleware layer
 
 Each middleware instance is an object implementing one callback per `ServiceWorker` event type to be handled:
@@ -222,4 +254,3 @@ A lot of this code has been inspired by different projects:
 Mozilla Public License 2.0
 
 http://mozilla.org/MPL/2.0/
-

--- a/lib/router.js
+++ b/lib/router.js
@@ -88,6 +88,11 @@ Router.prototype._sanitizeMethod = function(method) {
   Simple path-to-regex translation based on the Express "string-based path" syntax
 */
 Router.prototype._parseSimplePath = function(path) {
+  // Check for named placeholder crowding
+  if (/\:[a-zA-Z0-9]+\:[a-zA-Z0-9]+/g.test(path)) {
+    throw new Error('Invalid usage of named placeholders');
+  }
+
   // Try parsing the string and converting special characters into regex
   try {
     return new RegExp(path.replace(/(\*|\:[a-zA-Z0-9]+)/g, '(.*?)'));

--- a/lib/router.js
+++ b/lib/router.js
@@ -17,10 +17,21 @@ Router.prototype.methods = ['get', 'post', 'put', 'delete', 'head',
  * @param handler (Function) payload to be executed if url matches.
  */
 Router.prototype.add = function r_add(method, path, handler) {
+  var pathRegex;
+
   method = this._sanitizeMethod(method);
+
+  try {
+    pathRegex = new RegExp(path);
+  }
+
+  catch (ex) {
+    pathRegex = this._parseSimplePath(path);
+  }
+
   this.stack.push({
     method: method,
-    path: new RegExp(path),
+    path: pathRegex,
     handler: handler
   });
 };
@@ -77,5 +88,21 @@ Router.prototype._sanitizeMethod = function(method) {
   }
   return sanitizedMethod;
 };
+
+/*
+  Simple path-to-regex translation based on the Express "string-based path" syntax
+*/
+Router.prototype._parseSimplePath = function(path) {
+  // Try parsing the string and converting special characters into regex
+  try {
+    return new RegExp(path.replace(/(\*|\:[a-zA-Z0-9]+)/g, '(.*?)'));
+  }
+
+  // Sanitize string as a literal
+  catch (ex) {
+    return new RegExp(path.replace(/[|\\{}()[\]^$+*?.]/g,'\\$&'));
+  }
+};
+
 
 module.exports = Router;

--- a/lib/router.js
+++ b/lib/router.js
@@ -108,9 +108,9 @@ Router.prototype._parseSimplePath = function(path) {
     return new RegExp(path);
   }
 
-  // Sanitize string as a literal
+  // Failed to parse final path as a RegExp
   catch (ex) {
-    return new RegExp(path.replace(/[|\\{}()[\]^$+*?.]/g,'\\$&'));
+    throw new Error('Invalid path specified');
   }
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -95,7 +95,9 @@ Router.prototype._parseSimplePath = function(path) {
 
   // Try parsing the string and converting special characters into regex
   try {
-    return new RegExp(path.replace(/(\*|\:[a-zA-Z0-9]+)/g, '(.*?)'));
+    path = path.replace(/\*/g, '(.*?)');
+    path = path.replace(/\:[a-zA-Z0-9]+/g, '(.+?)');
+    return new RegExp(path);
   }
 
   // Sanitize string as a literal

--- a/lib/router.js
+++ b/lib/router.js
@@ -93,6 +93,11 @@ Router.prototype._parseSimplePath = function(path) {
     throw new Error('Invalid usage of named placeholders');
   }
 
+  // Check for mixed placeholder crowdings
+  if (/(\*\:[a-zA-Z0-9]+)|(\:[a-zA-Z0-9]+\:[a-zA-Z0-9]+)|(\:[a-zA-Z0-9]+\*)/g.test(path.replace(/\\\*/g,''))) {
+    throw new Error('Invalid usage of named placeholders');
+  }
+
   // Try parsing the string and converting special characters into regex
   try {
     // Parsing anonymous placeholders with simple backslash-escapes

--- a/lib/router.js
+++ b/lib/router.js
@@ -21,15 +21,8 @@ Router.prototype.add = function r_add(method, path, handler) {
 
   method = this._sanitizeMethod(method);
 
-  try {
-    // TODO: figure out backward compatibility & arbitrary regexes
-    throw new Exception(); // disable default regex parsing
-    pathRegex = new RegExp(path);
-  }
-
-  catch (ex) {
-    pathRegex = this._parseSimplePath(path);
-  }
+  // Parse simle string path into regular expression for path matching
+  pathRegex = this._parseSimplePath(path);
 
   this.stack.push({
     method: method,

--- a/lib/router.js
+++ b/lib/router.js
@@ -22,6 +22,8 @@ Router.prototype.add = function r_add(method, path, handler) {
   method = this._sanitizeMethod(method);
 
   try {
+    // TODO: figure out backward compatibility & arbitrary regexes
+    throw new Exception(); // disable default regex parsing
     pathRegex = new RegExp(path);
   }
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -97,12 +97,12 @@ Router.prototype._parseSimplePath = function(path) {
   try {
     // Parsing anonymous placeholders with simple backslash-escapes
     path = path.replace(/(.|^)\*/g, function(m,escape) {
-      return escape==='\\'?'\\*':(escape+'(.*?)');
+      return escape==='\\' ? '\\*' : (escape+'(.*?)');
     });
 
     // Parsing named placeholders with backslash-escapes
     path = path.replace(/(.|^)\:([a-zA-Z0-9]+)/g, function(m,escape,tag) {
-      return escape==='\\'?(':'+tag):(escape+'(.+?)');
+      return escape==='\\' ? (':'+tag) : (escape+'(.+?)');
     });
 
     return new RegExp(path);

--- a/lib/router.js
+++ b/lib/router.js
@@ -95,8 +95,16 @@ Router.prototype._parseSimplePath = function(path) {
 
   // Try parsing the string and converting special characters into regex
   try {
-    path = path.replace(/\*/g, '(.*?)');
-    path = path.replace(/\:[a-zA-Z0-9]+/g, '(.+?)');
+    // Parsing anonymous placeholders with simple backslash-escapes
+    path = path.replace(/(.|^)\*/g, function(m,escape) {
+      return escape==='\\'?'\\*':(escape+'(.*?)');
+    });
+
+    // Parsing named placeholders with backslash-escapes
+    path = path.replace(/(.|^)\:([a-zA-Z0-9]+)/g, function(m,escape,tag) {
+      return escape==='\\'?(':'+tag):(escape+'(.+?)');
+    });
+
     return new RegExp(path);
   }
 

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -291,11 +291,21 @@ describe('Router instances', function () {
         expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
       });
 
-      xit('placeholder crowding (**) should ??? ', function() {
-        router.get('/foo/**', mw);
-        router.get('/f**bar', mw);
-        //expect(router.match('get', '/')).to.be.?;
-        //throw? degrade gracefully? treat as single placeholder? other?
+      it('placeholder crowding for anonymous placeholder (**) should be treated same as a single placeholder', function() {
+        var mw2 = function () {};
+
+        expect(function() { router.get('/f**bar', mw) }).to.not.throw;
+        router.get('/f*bar', mw2);
+
+        expect(router.match('get', '/foo')).to.deep.equal(router.match('get', '/foo'));
+        expect(router.match('get', '/foobar')).to.deep.equal(router.match('get', '/foobar'));
+        expect(router.match('get', '/foobabarbar')).to.deep.equal(router.match('get', '/foobabarbar'));
+        expect(router.match('get', '/foo/bar/baz')).to.deep.equal(router.match('get', '/foo/bar/baz'));
+        expect(router.match('get', '/foo/doh/bar')).to.deep.equal(router.match('get', '/foo/doh/bar'));
+      });
+
+      it('placeholder crowding for named placeholder (:foo:bar) should throw', function() {
+        expect(function () { router.get('/foo/:bar:baz', mw) }).to.throw(Error, 'Invalid usage of named placeholders');
       });
 
     });

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -295,7 +295,8 @@ describe('Router instances', function () {
       it('placeholder crowding for anonymous placeholder (**) should be treated same as a single placeholder', function() {
         var mw2 = function () {};
 
-        expect(function() { router.get('/f**bar', mw); }).to.not.throw;
+        expect(function() { router.get('/f**bar', mw); }).to.not.throw();
+        expect(function() { router.get('/foo/bar/***', mw); }).to.not.throw();
         router.get('/f*bar', mw2);
 
         expect(router.match('get', '/foo')).to.deep.equal(router.match('get', '/foo'));
@@ -307,8 +308,14 @@ describe('Router instances', function () {
 
       it('placeholder crowding for named placeholder (:foo:bar) should throw', function() {
         expect(function () { router.get('/foo/:bar:baz', mw); }).to.throw(Error, 'Invalid usage of named placeholders');
+        expect(function () { router.get('/foo/:bar:baz:shoo', mw); }).to.throw(Error, 'Invalid usage of named placeholders');
       });
 
+      it('mixed crowdings (*:foo, :bar** etc.) should throw', function() {
+        expect(function () { router.get('/foo/*:bar', mw); }).to.throw(Error, 'Invalid usage of named placeholders');
+        expect(function () { router.get('/:foo**/:bar', mw); }).to.throw(Error, 'Invalid usage of named placeholders');
+        expect(function () { router.get('/foo/\\*:bar', mw); }).to.not.throw();
+      });
     });
 
     describe('_parseSimplePath()', function() {

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -246,14 +246,14 @@ describe('Router instances', function () {
       it('infix placeholders (/foo/*/bar etc.) should match arbitrary path chunks', function() {
         var mw2 = function () {};
 
-        router.get('/foo/*', mw);
-        router.get('/foo/bar/*', mw2);
+        router.get('/foo*bar', mw);
+        router.get('/foo/*/bar', mw2);
 
         expect(router.match('get', '/')).to.be.empty;
         expect(router.match('get', '/foo')).to.be.empty;
-        expect(router.match('get', '/foo/')).to.deep.equal([mw]);
         expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
-        expect(router.match('get', '/foo/bar/baz')).to.deep.equal([mw, mw2]);
+        expect(router.match('get', '/foo/doh/bar')).to.deep.equal([mw, mw2]);
+        expect(router.match('get', '/foobar/baz')).to.deep.equal([mw]);
       });
 
       it('multiple placeholders (/foo/*/bar/* etc) should be allowed', function() {

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -237,7 +237,8 @@ describe('Router instances', function () {
         router.get('/foo/bar/*', mw2);
 
         expect(router.match('get', '/')).to.be.empty;
-        expect(router.match('get', '/foo')).to.deep.equal([mw]);
+        expect(router.match('get', '/foo')).to.be.empty;
+        expect(router.match('get', '/foo/')).to.deep.equal([mw]);
         expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
         expect(router.match('get', '/foo/bar/baz')).to.deep.equal([mw, mw2]);
       });
@@ -249,7 +250,8 @@ describe('Router instances', function () {
         router.get('/foo/bar/*', mw2);
 
         expect(router.match('get', '/')).to.be.empty;
-        expect(router.match('get', '/foo')).to.deep.equal([mw]);
+        expect(router.match('get', '/foo')).to.be.empty;
+        expect(router.match('get', '/foo/')).to.deep.equal([mw]);
         expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
         expect(router.match('get', '/foo/bar/baz')).to.deep.equal([mw, mw2]);
       });

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -337,8 +337,8 @@ describe('Router instances', function () {
       });
 
       it('should support escaping of placeholder special characters (* and :)', function() {
-        expect(router._parseSimplePath('/a\\*/*/b').source).to.equal("\\/a\\*\\/(.*?)\\:80\\/b");
-        expect(router._parseSimplePath('/a/:foo\\:80/b').source).to.equal("\\/a\\/(.+?)\\:80\\/b");
+        expect(router._parseSimplePath('/a\\*/*/b').source).to.equal("\\/a\\*\\/(.*?)\\/b");
+        expect(router._parseSimplePath('/a/:foo\\:80/b').source).to.equal("\\/a\\/(.+?):80\\/b");
       });
     });
 

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -207,18 +207,18 @@ describe('Router instances', function () {
   });
 
 
-  describe('Reworked matching algorithm (#1165858)', function() {
+  describe('Matching algorithm', function() {
     describe('match()', function() {
       var mw = function() {};
 
-      it('should match trivial registrations (*)', function() {
+      it('should match universal registrations (*)', function() {
         router.get('*', mw);
 
         expect(router.match('get', '/')).to.deep.equal([mw]);
         expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
       });
 
-      it('should match all trivial registrations (*) in order', function() {
+      it('should match all universal registrations (*) in order', function() {
         var mw2 = function () {},
             mw3 = function () {};
 

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -317,8 +317,8 @@ describe('Router instances', function () {
     });
 
     describe('_parseSimplePath()', function() {
-      xit('on invalid registrations it should ???', function() {
-        expect(router._parseSimplePath('][')).to.not.throw;
+      it('on invalid path specification it should throw an error', function() {
+        expect(function () { router._parseSimplePath(']['); }).to.throw(Error, 'Invalid path specified');
         // not throw? gracefully degrade? other?
       });
 

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -211,14 +211,14 @@ describe('Router instances', function () {
     describe('match()', function() {
       var mw = function() {};
 
-      it('should match universal registrations (*)', function() {
+      it('should match anonymous placeholders (*)', function() {
         router.get('*', mw);
 
         expect(router.match('get', '/')).to.deep.equal([mw]);
         expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
       });
 
-      it('should match all universal registrations (*) in order', function() {
+      it('should match all anonymous placeholders (*) in order', function() {
         var mw2 = function () {},
             mw3 = function () {};
 
@@ -285,15 +285,10 @@ describe('Router instances', function () {
         expect(router.match('get', '/pre/suf/inner/fix/')).to.deep.equal([mw, mw2, mw3]);
       });
 
-      it('named placeholders (:foo) should match similar to anonymous ones', function() {
-        router.get('/:foo', mw);
-        expect(router.match('get', '/foo')).to.deep.equal([mw]);
-        expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
-      });
-
       it('named placeholders (:foo) must match at least one character (no empty matches allowed)', function() {
         router.get('/:foo', mw);
         expect(router.match('get', '/')).to.be.empty;
+        expect(router.match('get', '/foo')).to.deep.equal([mw]);
         expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
       });
 

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -206,4 +206,98 @@ describe('Router instances', function () {
     });
   });
 
+
+  describe('Reworked matching algorithm (#1165858)', function() {
+    describe('match()', function() {
+      var mw = function() {};
+
+      it('should match trivial registrations (*)', function() {
+        router.get('*', mw);
+
+        expect(router.match('get', '/')).to.deep.equal([mw]);
+        expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
+      });
+
+      it('should match all trivial registrations (*) in order', function() {
+        var mw2 = function () {},
+            mw3 = function () {};
+
+        router.get('*', mw);
+        router.get('/foo/bar', mw2);
+        router.get('*', mw3);
+
+        expect(router.match('get', '/')).to.deep.equal([mw, mw3]);
+        expect(router.match('get', '/foo/bar')).to.deep.equal([mw, mw2, mw3]);
+      });
+
+      it('trailing placeholders (/foo/* etc.) should match arbitrary prefixes', function() {
+        var mw2 = function () {};
+
+        router.get('/foo/*', mw);
+        router.get('/foo/bar/*', mw2);
+
+        expect(router.match('get', '/')).to.be.empty;
+        expect(router.match('get', '/foo')).to.deep.equal([mw]);
+        expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
+        expect(router.match('get', '/foo/bar/baz')).to.deep.equal([mw, mw2]);
+      });
+
+      it('infix placeholders (/foo/*/bar etc.) should match arbitrary path chunks', function() {
+        var mw2 = function () {};
+
+        router.get('/foo/*', mw);
+        router.get('/foo/bar/*', mw2);
+
+        expect(router.match('get', '/')).to.be.empty;
+        expect(router.match('get', '/foo')).to.deep.equal([mw]);
+        expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
+        expect(router.match('get', '/foo/bar/baz')).to.deep.equal([mw, mw2]);
+      });
+
+      it('multiple placeholders (/foo/*/bar/* etc) should be allowed', function() {
+        var mw2 = function () {},
+            mw3 = function () {};
+
+        router.get('/pre/*/fix/*', mw);
+        router.get('*/suf/*/fix', mw2);
+        router.get('*inner*', mw3);
+
+        expect(router.match('get', '/')).to.be.empty;
+        expect(router.match('get', '/pre/123/fix/')).to.deep.equal([mw]);
+        expect(router.match('get', '/pre/123/fix/456')).to.deep.equal([mw]);
+        expect(router.match('get', '/pre/123/')).to.be.empty;
+
+        expect(router.match('get', '/matched/suf/123/fix')).to.deep.equal([mw2]);
+        expect(router.match('get', '/any/other/suf/123/456/fix')).to.deep.equal([mw2]);
+        expect(router.match('get', '/suf/nopre/fix')).to.deep.equal([mw2]);
+        expect(router.match('get', '/fix')).to.be.empty;
+
+        expect(router.match('get', '/pre/suf/fix/')).to.deep.equal([mw]);
+
+        expect(router.match('get', '/inner')).to.deep.equal([mw3]);
+        expect(router.match('get', '/beginners')).to.deep.equal([mw3]);
+        expect(router.match('get', '/pre/inner/fix/')).to.deep.equal([mw, mw3]);
+        expect(router.match('get', '/inner/suf/other/fix/')).to.deep.equal([mw2, mw3]);
+
+        expect(router.match('get', '/pre/123/fix/inner/suf/456/fix/')).to.deep.equal([mw, mw2, mw3]);
+        expect(router.match('get', '/pre/suf/inner/fix/')).to.deep.equal([mw, mw2, mw3]);
+      });
+
+      it('named placeholders (:foo) should match as anonymous placeholders (*)', function() {
+        router.get('/:foo', mw);
+        expect(router.match('get', '/')).to.deep.equal([mw]);
+        expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
+      });
+
+      xit('placeholder crowding (**) should ??? ', function() {
+        router.get('/foo/**', mw);
+        router.get('/f**bar', mw);
+        //expect(router.match('get', '/')).to.be.?;
+        //throw? degrade gracefully? treat as single placeholder? other?
+      });
+
+    });
+
+  });
+
 });

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -298,6 +298,22 @@ describe('Router instances', function () {
 
     });
 
+    describe('_parseSimplePath()', function() {
+      xit('on invalid registrations it should ???', function() {
+        expect(router._parseSimplePath('][')).to.not.throw;
+        // not throw? gracefully degrade? other?
+      });
+
+      it('should support anonymous placeholders (*)', function() {
+        expect(router._parseSimplePath('/a*b').source).to.equal("\\/a(.*?)b");
+      });
+
+      it('should support named placeholders (:foo)', function() {
+        expect(router._parseSimplePath('/a/:foo/b').source).to.equal("\\/a\\/(.*?)\\/b");
+      });
+
+    });
+
   });
 
 });

--- a/lib/spec/router.sw-spec.js
+++ b/lib/spec/router.sw-spec.js
@@ -285,16 +285,22 @@ describe('Router instances', function () {
         expect(router.match('get', '/pre/suf/inner/fix/')).to.deep.equal([mw, mw2, mw3]);
       });
 
-      it('named placeholders (:foo) should match as anonymous placeholders (*)', function() {
+      it('named placeholders (:foo) should match similar to anonymous ones', function() {
         router.get('/:foo', mw);
-        expect(router.match('get', '/')).to.deep.equal([mw]);
+        expect(router.match('get', '/foo')).to.deep.equal([mw]);
+        expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
+      });
+
+      it('named placeholders (:foo) must match at least one character (no empty matches allowed)', function() {
+        router.get('/:foo', mw);
+        expect(router.match('get', '/')).to.be.empty;
         expect(router.match('get', '/foo/bar')).to.deep.equal([mw]);
       });
 
       it('placeholder crowding for anonymous placeholder (**) should be treated same as a single placeholder', function() {
         var mw2 = function () {};
 
-        expect(function() { router.get('/f**bar', mw) }).to.not.throw;
+        expect(function() { router.get('/f**bar', mw); }).to.not.throw;
         router.get('/f*bar', mw2);
 
         expect(router.match('get', '/foo')).to.deep.equal(router.match('get', '/foo'));
@@ -305,7 +311,7 @@ describe('Router instances', function () {
       });
 
       it('placeholder crowding for named placeholder (:foo:bar) should throw', function() {
-        expect(function () { router.get('/foo/:bar:baz', mw) }).to.throw(Error, 'Invalid usage of named placeholders');
+        expect(function () { router.get('/foo/:bar:baz', mw); }).to.throw(Error, 'Invalid usage of named placeholders');
       });
 
     });
@@ -321,9 +327,19 @@ describe('Router instances', function () {
       });
 
       it('should support named placeholders (:foo)', function() {
-        expect(router._parseSimplePath('/a/:foo/b').source).to.equal("\\/a\\/(.*?)\\/b");
+        expect(router._parseSimplePath('/a/:foo/b').source).to.equal("\\/a\\/(.+?)\\/b");
       });
 
+      it('should support multiple/mixed placeholders (*, :foo)', function() {
+        expect(router._parseSimplePath('/a/*/*/b').source).to.equal("\\/a\\/(.*?)\\/(.*?)\\/b");
+        expect(router._parseSimplePath('/a/:foo/:bar/b').source).to.equal("\\/a\\/(.+?)\\/(.+?)\\/b");
+        expect(router._parseSimplePath('/a/*/:foo/b').source).to.equal("\\/a\\/(.*?)\\/(.+?)\\/b");
+      });
+
+      it('should support escaping of placeholder special characters (* and :)', function() {
+        expect(router._parseSimplePath('/a\\*/*/b').source).to.equal("\\/a\\*\\/(.*?)\\:80\\/b");
+        expect(router._parseSimplePath('/a/:foo\\:80/b').source).to.equal("\\/a\\/(.+?)\\:80\\/b");
+      });
     });
 
   });


### PR DESCRIPTION
Preliminary implementation of the new route matching algorithm + tests:
* I have added basic support for the `*` token which matches arbitrary-length substrings (and is basically translated to `(.*?)`)
* at the moment the `:foobar123`-style tokens are currently simple aliases for the `*` token, their role might later be more refined (arbitrary matching rules, or more restricted translation like `(\w+)`
* I have removed backward compatibility with paths specified with RegExp-syntax

There are two disabled tests, until we decide what to do in the situations:
* Placeholder-crowding (`**`, `:foo:bar` etc.)
* Invalid characters/syntax in path string